### PR TITLE
Live does not depend on the DB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,6 @@ services:
         networks:
             - app-network
         depends_on:
-            - db
             - redis
         restart: always
         command: 


### PR DESCRIPTION
Docker does not need to wait for DB to launch the Live server