### PR TITLE
Convert players after FE change

### DIFF
--- a/server/workers/nfl/phase.nfl.ts
+++ b/server/workers/nfl/phase.nfl.ts
@@ -54,13 +54,14 @@ async function setPhase(teamID: number, newphase: GamePhaseType) {
       },
     });
 
-    // Convert players to points if game ended
-    if (newphase === 'post') await convertTeamPlayers(teamID);
-
     // Announce phase change
     phaseChange.pub(teamID, newphase);
+
     // Delete cache entry
     client.DEL('/nfldata/games');
+
+    // Convert players to points if game ended
+    if (newphase === 'post') await convertTeamPlayers(teamID);
   } catch (error) {
     logger.error(error);
   }


### PR DESCRIPTION
Send out a message about a game phase change before trying to convert players. Would make it less likely for a user to modify entry during conversion